### PR TITLE
feat(server): CORS origin match support wildcard

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,7 +27,7 @@ func init() {
 	flag.StringVar(&host, "host", "localhost", "host to listen on")
 	flag.IntVar(&port, "port", 8080, "port to listen on")
 	flag.StringVar(&logLevel, "log-level", "info", "log level")
-	flag.Var(&allowedOrigins, "allowed-origin", "allowed request origin")
+	flag.Var(&allowedOrigins, "allowed-origin", "allowed request origin(support wildcard match except \"-\")")
 	flag.BoolVar(&debug, "debug", false, "enable debug mode")
 	flag.Parse()
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 0%
+

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -49,14 +49,7 @@ func (s *APIServer) PrepareRun() error {
 		Debug:            s.debug,
 		AllowCredentials: true,
 		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete},
-		AllowOriginFunc: func(origin string) bool {
-			for _, allowed := range s.allowedOrigins {
-				if allowed == origin {
-					return true
-				}
-			}
-			return false
-		},
+		AllowOriginFunc:  allowOriginFunc(s.allowedOrigins),
 	})
 
 	s.Server.Handler = c.Handler(s.container)

--- a/pkg/apiserver/util.go
+++ b/pkg/apiserver/util.go
@@ -8,3 +8,32 @@ import (
 func nameOfFunction(f interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 }
+
+func allowOriginFunc(allowedOrigins []string) func(origin string) bool {
+	return func(origin string) bool {
+		for _, allowed := range allowedOrigins {
+			if wildcardMatch([]rune(allowed), []rune(origin)) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func wildcardMatch(pattern, str []rune) bool {
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			// not match '-'(ascii: 45) with *
+			return wildcardMatch(pattern[1:], str) || (len(str) > 0 && wildcardMatch(pattern, str[1:]) && str[0] != 45)
+		default:
+			if len(str) == 0 || str[0] != pattern[0] {
+				return false
+			}
+		}
+		str = str[1:]
+		pattern = pattern[1:]
+	}
+
+	return len(str) == 0 && len(pattern) == 0
+}

--- a/pkg/apiserver/util.go
+++ b/pkg/apiserver/util.go
@@ -24,8 +24,8 @@ func wildcardMatch(pattern, str []rune) bool {
 	for len(pattern) > 0 {
 		switch pattern[0] {
 		case '*':
-			// not match '-'(ascii: 45) with *
-			return wildcardMatch(pattern[1:], str) || (len(str) > 0 && wildcardMatch(pattern, str[1:]) && str[0] != 45)
+			// not match '-'(ascii: 0x2d/45) with *
+			return wildcardMatch(pattern[1:], str) || (len(str) > 0 && wildcardMatch(pattern, str[1:]) && str[0] != 0x2d)
 		default:
 			if len(str) == 0 || str[0] != pattern[0] {
 				return false

--- a/pkg/apiserver/util_test.go
+++ b/pkg/apiserver/util_test.go
@@ -1,0 +1,30 @@
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowOriginFunc(t *testing.T) {
+	allowedOrigins := []string{"http://localhost:8000", "http://example.com", "http://test-*-app.example.com"}
+	allowOriginFunc := allowOriginFunc(allowedOrigins)
+	assert.Equal(t, true, allowOriginFunc("http://localhost:8000"))
+	assert.Equal(t, false, allowOriginFunc("http://example.com:8000"))
+	assert.Equal(t, true, allowOriginFunc("http://example.com"))
+	assert.Equal(t, true, allowOriginFunc("http://test-hello-app.example.com"))
+	assert.Equal(t, true, allowOriginFunc("http://test-world-app.example.com"))
+	assert.Equal(t, false, allowOriginFunc("http://test1-hello-app.example.com"))
+	assert.Equal(t, false, allowOriginFunc("http://test-hello-sss-app.example.com"))
+}
+
+func TestWildcardMatch(t *testing.T) {
+	assert.Equal(t, true, wildcardMatch([]rune(""), []rune("")))
+	assert.Equal(t, true, wildcardMatch([]rune("*"), []rune("123")))
+	assert.Equal(t, true, wildcardMatch([]rune("12*45"), []rune("12345")))
+	assert.Equal(t, true, wildcardMatch([]rune("12*45"), []rune("12333345")))
+	assert.Equal(t, false, wildcardMatch([]rune("12*45"), []rune("123-3345")))
+	assert.Equal(t, true, wildcardMatch([]rune("1-*-3"), []rune("1-2333-3")))
+	assert.Equal(t, true, wildcardMatch([]rune("1-*-3"), []rune("1-3-3")))
+	assert.Equal(t, false, wildcardMatch([]rune("1-*-3"), []rune("1-3-3-3")))
+}


### PR DESCRIPTION
wildcard match except "-"(hyphen-minus, ascii 45/0x2d)
- http://localhost:8000 **match** http://localhost:8000
- http://test-hello-app.example.com **match** http://test-*-app.example.com
- http://test-world-app.example.com **match** http://test-*-app.example.com
- http://test-hello-world-app.example.com **not match** http://test-*-app.example.com